### PR TITLE
Add support for kernel-space forwarding on Linux

### DIFF
--- a/include/mrdpriv/ks_mfa.h
+++ b/include/mrdpriv/ks_mfa.h
@@ -1,6 +1,6 @@
 /*
  * Multicast Routing Daemon (MRD)
- *   bsd/mfa.h
+ *   ks_mfa.h
  *
  * Copyright (C) 2006, 2007 - Hugo Santos
  * Copyright (C) 2004..2006 - Universidade de Aveiro, IT Aveiro
@@ -22,8 +22,8 @@
  * Author:  Hugo Santos <hugo@fivebits.net>
  */
 
-#ifndef _mrd_bsd_mfa_h_
-#define _mrd_bsd_mfa_h_
+#ifndef _mrd_ks_mfa_h_
+#define _mrd_ks_mfa_h_
 
 #include <list>
 #include <map>
@@ -35,21 +35,26 @@
 #include <mrd/mrd.h>
 #include <mrd/timers.h>
 #include <sys/param.h>
+
+#ifdef OS_LINUX
+#include <linux/mroute6.h>
+#else
 #include <netinet6/ip6_mroute.h>
+#endif
 
 class interface;
 class router;
 
 struct ip6_hdr;
 
-class bsd_mfa_group_source;
-class bsd_mfa_group;
-class bsd_mfa;
+class ks_mfa_group_source;
+class ks_mfa_group;
+class ks_mfa;
 
-class bsd_mfa_group_source : public mfa_group_source {
+class ks_mfa_group_source : public mfa_group_source {
 public:
-	bsd_mfa_group_source(bsd_mfa_group *, const in6_addr &, uint32_t, action *);
-	virtual ~bsd_mfa_group_source();
+	ks_mfa_group_source(ks_mfa_group *, const in6_addr &, uint32_t, action *);
+	virtual ~ks_mfa_group_source();
 
 	const in6_addr &address() const { return m_addr.address(); }
 
@@ -72,23 +77,23 @@ public:
 private:
 	typedef std::vector<interface *> oifs;
 
-	bsd_mfa_group *m_owner;
+	ks_mfa_group *m_owner;
 	inet6_addr m_addr;
 
 	interface *m_iif;
 	oifs m_oifs;
 
-	mf6cctl m_bsd_state;
+	mf6cctl m_ks_state;
 
 	uint32_t m_flags;
 	uint32_t m_interest_flags;
 
-	friend class bsd_mfa;
+	friend class ks_mfa;
 };
 
-class bsd_mfa_group : public mfa_group {
+class ks_mfa_group : public mfa_group {
 public:
-	bsd_mfa_group(router *, const inet6_addr &);
+	ks_mfa_group(router *, const inet6_addr &);
 
 	const inet6_addr &addr() const { return m_addr; }
 
@@ -103,9 +108,9 @@ public:
 	void output_info(base_stream &) const;
 
 private:
-	bsd_mfa_group_source *match_source(const in6_addr &addr) const;
+	ks_mfa_group_source *match_source(const in6_addr &addr) const;
 
-	typedef std::map<in6_addr, bsd_mfa_group_source *> sources;
+	typedef std::map<in6_addr, ks_mfa_group_source *> sources;
 
 	sources m_sources;
 
@@ -123,7 +128,7 @@ private:
 	mfa_group_source::action m_actions[mfa_group_source::event_count];
 };
 
-inline bsd_mfa_group_source *bsd_mfa_group::match_source(const in6_addr &addr) const {
+inline ks_mfa_group_source *ks_mfa_group::match_source(const in6_addr &addr) const {
 	sources::const_iterator k = m_sources.find(addr);
 	if (k != m_sources.end()) {
 		return k->second;
@@ -132,9 +137,9 @@ inline bsd_mfa_group_source *bsd_mfa_group::match_source(const in6_addr &addr) c
 	return 0;
 }
 
-class bsd_mfa : public mfa_core {
+class ks_mfa : public mfa_core {
 public:
-	bsd_mfa();
+	ks_mfa();
 
 	bool pre_startup();
 	bool check_startup();
@@ -165,31 +170,31 @@ public:
 	uint32_t m_grpflags;
 	mfa_group_source::action m_grpactions[mfa_group_source::event_count];
 
-	void get_input_counter(const bsd_mfa_group_source *, uint64_t &);
-	void get_forwarding_counter(const bsd_mfa_group_source *, uint64_t &);
+	void get_input_counter(const ks_mfa_group_source *, uint64_t &);
+	void get_forwarding_counter(const ks_mfa_group_source *, uint64_t &);
 
-	void get_source_counters(const bsd_mfa_group_source *, sioc_sg_req6 *);
+	void get_source_counters(const ks_mfa_group_source *, sioc_sg_req6 *);
 
 private:
 	int m_icmpsock;
 
 	void kernel_data_pending(uint32_t);
 
-	socket0<bsd_mfa> m_sock;
+	socket0<ks_mfa> m_sock;
 
 	std::map<interface *, int> vifs;
 	std::map<int, interface *> rev_vifs;
 
 	data_plane_source_discovery data_plane_sourcedisc;
 
-	bsd_mfa_group *match_group(const in6_addr &) const;
+	ks_mfa_group *match_group(const in6_addr &) const;
 
-	typedef std::map<inet6_addr, bsd_mfa_group *> groups;
+	typedef std::map<inet6_addr, ks_mfa_group *> groups;
 
 	groups m_groups;
 };
 
-inline bsd_mfa_group *bsd_mfa::match_group(const in6_addr &addr) const {
+inline ks_mfa_group *ks_mfa::match_group(const in6_addr &addr) const {
 	for (groups::const_iterator k = m_groups.begin();
 				k != m_groups.end(); ++k) {
 		if (k->first.matches(addr)) {
@@ -200,7 +205,7 @@ inline bsd_mfa_group *bsd_mfa::match_group(const in6_addr &addr) const {
 	return 0;
 }
 
-inline bool bsd_mfa_group_source::has_oif(interface *oif) const {
+inline bool ks_mfa_group_source::has_oif(interface *oif) const {
 	return std::find(m_oifs.begin(), m_oifs.end(), oif) != m_oifs.end();
 }
 

--- a/src/Makefile
+++ b/src/Makefile
@@ -47,7 +47,7 @@ INCLUDES = -I../include
 NOW = $(shell date -u)
 
 SOURCES = address.cpp address_set.cpp group.cpp icmp_inet6.cpp icmp.cpp \
-	  interface.cpp log.cpp mfa.cpp mrd.cpp mrib.cpp node.cpp \
+	  interface.cpp ks_mfa.cpp log.cpp mfa.cpp mrd.cpp mrib.cpp node.cpp \
 	  parser.cpp rib.cpp router.cpp timers.cpp support/objpool.cpp \
 	  support/ptree.cpp
 
@@ -60,7 +60,7 @@ ifeq ($(PLATFORM),OS_LINUX)
 endif
 
 ifeq ($(PLATFORM),OS_BSD)
-	SOURCES += bsd/bsd_rib.cpp bsd/bsd_mfa.cpp bsd/mrd_components.cpp
+	SOURCES += bsd/bsd_rib.cpp bsd/mrd_components.cpp
 endif
 
 MLD_SOURCES = mld/mld_def.cpp mld/mld_router.cpp mld/mld_conf.cpp mld/mld_module.cpp

--- a/src/bsd/mrd_components.cpp
+++ b/src/bsd/mrd_components.cpp
@@ -24,11 +24,11 @@
 
 #include <mrd/mrd.h>
 
-#include <mrdpriv/bsd/mfa.h>
+#include <mrdpriv/ks_mfa.h>
 #include <mrdpriv/bsd/rib.h>
 
 bool mrd::prepare_os_components() {
-	m_mfa = new bsd_mfa();
+	m_mfa = new ks_mfa();
 
 	return true;
 }


### PR DESCRIPTION
Hi,

as the Linux kernel supports IPv6 multicast forwarding for some years now,
I thought it'd be good to add support to mrd6. My changes make mrd6 use the
bsd_mfa code (which I renamed to ks_mfa) on Linux by default, but still allow to fall
back to user-space forwarding if the kernel is compiled without CONFIG_IPV6_MROUTE.

Forwarding works great, I haven't compile-tested the changes on *BSD though.
