### PR TITLE
Fix errors and warnings from last build on amd64.

### DIFF
--- a/include/mrd/support/ptree.h
+++ b/include/mrd/support/ptree.h
@@ -35,6 +35,7 @@
 #ifndef _Ptree_h_
 #define _Ptree_h_
 
+#include <cstddef>
 #include <stdint.h>
 #include <algorithm>
 #include <mrd/log.h>

--- a/src/parser.cpp
+++ b/src/parser.cpp
@@ -171,7 +171,7 @@ int parser_context::eat(int count, ...) {
 int parser_context::read_token(bool strict, int *sym, const char **symstart,
 			       bool eat) {
 	int res, readnum;
-	int pointer = 0, prevpointer = 0;
+	int pointer = 0;
 	int linenumber = m_current_line;
 	int state = 0;
 	const char *currline = m_input_line_start;
@@ -236,7 +236,6 @@ int parser_context::read_token(bool strict, int *sym, const char **symstart,
 			break;
 		}
 
-		prevpointer = pointer;
 		pointer += readnum;
 	}
 

--- a/src/timers.cpp
+++ b/src/timers.cpp
@@ -403,7 +403,7 @@ bool timermgr::output_info(base_stream &ctx, bool extended) const {
 		namelen = 50;
 
 	char fmt[64];
-	snprintf(fmt, sizeof(fmt), "| %%%is | %%12s | %%10s | %%8s |", (int)namelen);
+	snprintf(fmt, sizeof(fmt), "| %%%zs | %%12s | %%10s | %%8s |", namelen);
 
 	_draw_sep(ctx, namelen);
 	ctx.printf(fmt, "timer name", "time left", "interval", "repeat").newl();


### PR DESCRIPTION
Hello Hugo,

here is a patch which fix the errors and warning I got in my last build of mrd6 on amd64. Feel free to merge
- Missing cstddef include in ptree.h for g++ to know ptrdiff_t
- Uses %z for displaying the content of a size_t variable
- Remove unaccessed prevpointer in parser.cpp
