### PR TITLE
Include libdl only if necessary

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -51,7 +51,9 @@ SOURCES = address.cpp address_set.cpp group.cpp icmp_inet6.cpp icmp.cpp \
 	  parser.cpp rib.cpp router.cpp timers.cpp support/objpool.cpp \
 	  support/ptree.cpp
 
+ifneq ($(shell $(CXX) -c test_dl_inclusion_in_libc.cpp 1>/dev/null 2>&1 ; echo $$? ; rm -f test_dl_inclusion_in_libc.o),0)
 LDFLAGS += -ldl # mrd.cpp requires dl* functions
+endif
 
 ifeq ($(PLATFORM),OS_LINUX)
 	SOURCES += linux/us_mfa.cpp linux/linux_icmp_raw.cpp \

--- a/src/test_dl_inclusion_in_libc.cpp
+++ b/src/test_dl_inclusion_in_libc.cpp
@@ -1,0 +1,13 @@
+int main(void)
+{
+	void *(*dlopen_fct)(const char *filename, int flag);
+	char *(*dlerror_fct)(void);
+	void *(*dlsym_fct)(void *handle, const char *symbol);
+	int (*dlclose_fct)(void *handle);
+
+	dlopen_fct = dlopen;
+	dlerror_fct = dlerror;
+	dlsym_fct = dlsym;
+	dlclose_fct = dlclose;
+	return 0;
+}


### PR DESCRIPTION
Hello Hugo,

last pull-request for today. When trying to make mrd6 build on Debian GNU/kFreeBSD and Debian GNU/Hurd, I added a non conditional link to libdl in order to have dl\* functions. Later, when I tried to have this changes accepted while uploading mrd6 during the freeze the release team teached me that dl\* function are sometimes built in the libc on some (non Debian) systems. I wrote a small patch to test this which is the object of this pull request.

Basically what the patch does is to try to compile a small cpp file without linking to ldl. If the compilation does not work, it means we need to link to ldl. Also, the compiler make sure the dl\* functions mentionned in the header are of the correct type thanks to the assignment. Now that I re-read this patch, I'm not sure if the -c should not be absent (to try also the link, not just the compilation) and add a rm -f a.out at the end. Try this change and if it work I think it would improve the patch a bit. Anyway, I couldn't test this on a system without dl\* functions (I think solaris is such a system but I'm not sure).

Best regards.
