### PR TITLE
Fix snprintf format string in timer.cpp

### DIFF
--- a/src/timers.cpp
+++ b/src/timers.cpp
@@ -403,7 +403,7 @@ bool timermgr::output_info(base_stream &ctx, bool extended) const {
 		namelen = 50;
 
 	char fmt[64];
-	snprintf(fmt, sizeof(fmt), "| %%%zs | %%12s | %%10s | %%8s |", namelen);
+	snprintf(fmt, sizeof(fmt), "| %%%zis | %%12s | %%10s | %%8s |", namelen);
 
 	_draw_sep(ctx, namelen);
 	ctx.printf(fmt, "timer name", "time left", "interval", "repeat").newl();


### PR DESCRIPTION
Sorry Hugo, I made a mistake in last commit to fix snprintf format string. Below is the explaination.

Last commit modified snprintf format string  in timermgr::output_info
from "| %%%is | %%12s | %%10s | %%8s |" to "| %%%zs | %%12s | %%10s |
%%8s |". This is a mistake as z is a _length_ modifier and hence still
require the i conversion modifier. Apologize for that.
