### PR TITLE
Add support for s390x

### DIFF
--- a/include/mrd/log.h
+++ b/include/mrd/log.h
@@ -54,7 +54,7 @@ void stream_push_formated_type(base_stream &, const char *val);
 void stream_push_formated_type(base_stream &, const void *val);
 
 
-#ifdef __s390__
+#if defined (__s390__) && !defined (__s390x__)
 const char *stream_type_format_parameter(size_t);
 void stream_push_formated_type(base_stream &, size_t val);
 #endif

--- a/src/log.cpp
+++ b/src/log.cpp
@@ -667,7 +667,7 @@ void stream_push_formated_type(base_stream &os, const void *val) {
 	os.nprintf(32, "%p", val);
 }
 
-#ifdef __s390__
+#if defined (__s390__) && !defined (__s390x__)
 const char *stream_type_format_parameter(size_t) {
 	return "u";
 }


### PR DESCRIPTION
Exclude **s390x** from all the macro test for s390\* architectures.
