### PR TITLE
Correctly detect and enable new interfaces (Issue #23)

### DIFF
--- a/include/mrd/interface.h
+++ b/include/mrd/interface.h
@@ -204,7 +204,7 @@ private:
 
 	void add_remove_address(bool isnew, const inet6_addr &);
 	void broadcast_change_state(bool wasdown);
-	void set_enabled(bool);
+	void set_enabled(bool newstate, bool newiface=false);
 };
 
 uint16_t ipv6_checksum(uint8_t protocol, const in6_addr &src, const in6_addr &dst, const void *data, uint16_t len);

--- a/src/interface.cpp
+++ b/src/interface.cpp
@@ -292,12 +292,16 @@ void interface::broadcast_change_state(bool wasdown) {
 	}
 }
 
-void interface::set_enabled(bool newstate) {
-	bool wasdown = !up();
-
-	mif_enabled = newstate;
-
-	broadcast_change_state(wasdown);
+void interface::set_enabled(bool newstate, bool newiface) {
+	if (!newiface) {
+		bool wasdown = !up();
+		mif_enabled = newstate;
+		broadcast_change_state(wasdown);
+	} else {
+		mif_state = (newstate) ? Up : Down;
+		mif_enabled = newstate;
+		g_mrd->broadcast_interface_state_changed(this);
+	}
 }
 
 bool interface::attach_node(interface_node *node) {

--- a/src/linux/linux_unicast_route.cpp
+++ b/src/linux/linux_unicast_route.cpp
@@ -199,7 +199,7 @@ static void _install_interface(const interface_desc &d) {
 			((linux_unicast_router &)g_mrd->rib()).do_dump(RTM_GETADDR);
 		}
 
-		intf->change_state(d.up ? interface::Up : interface::Down);
+		intf->change_state((d.up | intf->up()) ? interface::Up : interface::Down);
 	}
 }
 

--- a/src/mrd.cpp
+++ b/src/mrd.cpp
@@ -1484,7 +1484,7 @@ interface *mrd::found_interface(int index, const char *name, int type,
 			      (uint32_t)intf->mtu());
 	}
 
-	intf->set_enabled(enabled);
+	intf->set_enabled(enabled, true);
 
 	return intf;
 }


### PR DESCRIPTION
When new interfaces are created while mrd6 is running, they are detected
but incorrectly added as down. This patch correctly manages the case of
enabling interfaces which were not previously available.

Signed-off-by: Luca Bruno lucab@debian.org
